### PR TITLE
perf: optimize release build

### DIFF
--- a/libsql/build.gradle.kts
+++ b/libsql/build.gradle.kts
@@ -91,6 +91,11 @@ dependencies {
 }
 
 cargo {
+    if (gradle.startParameter.taskNames.any { it.lowercase().contains("release") }) {
+        profile = "release"
+    } else {
+        profile = "debug"
+    }
     module = "./src/main/rust/"
     libname = "libsql_android"
     targets = listOf("arm", "arm64", "x86", "x86_64")


### PR DESCRIPTION
The APK size is currently ~500MB—kinda big for a to-do app. LOL :)

Stolen from: https://github.com/firezone/firezone/blob/e856dc5eb2052eff48212b94a6ebf86b2c1e67df/kotlin/android/app/build.gradle.kts#L227 